### PR TITLE
Fix segfault on "lldptool -t -i eth2 -V PFC -c enabled"

### DIFF
--- a/lldp_util.c
+++ b/lldp_util.c
@@ -1227,7 +1227,7 @@ int get_arg_val_list(char *ibuf, int ilen, int *ioff,
 		}
 		hexstr2bin(ibuf+*ioff, &arglen, sizeof(arglen));
 		*ioff += 2 * (int)sizeof(arglen);
-		if (ilen - *ioff >= arglen) {
+		if (ilen - *ioff >= 0) {
 			args[i] = ibuf+*ioff;
 			*ioff += arglen;
 			*(arglens+i) = arglen;
@@ -1237,7 +1237,7 @@ int get_arg_val_list(char *ibuf, int ilen, int *ioff,
 					   sizeof(argvalue_len));
 				argvalue_len = ntohs(argvalue_len);
 				*ioff += 2*sizeof(argvalue_len);
-				if (ilen - *ioff >= argvalue_len) {
+				if (ilen - *ioff >= 0) {
 					argvals[i] = ibuf+*ioff;
 					*ioff += argvalue_len;
 					*(argvallens+i) = argvalue_len;


### PR DESCRIPTION
As per the lldptoo-pfc man page, I should be able to do
  # lldptool -T -i eth2 -V PFC enabled=2
  # lldptool -t -i eth2 -V PFC -c enabled

but I get a segfault at
  0x000000000040a993 in get_arg_val_list (ibuf=0x7fffffffc2cd "07enabled",
  ilen=14, ioff=0x7fffffffb12c, args=0x6163e0, argvals=0x6163c0)
  at lldp_util.c:1239
    :

Squinting at the code, looks like the *ioff check against ilen
in get_arg_val_list is trying to see if we are still within
the ibuff before moving args[] and argvals[] forward, so it
should not really be testing against arglen/argvalue_len.